### PR TITLE
Add virtual assistant gallery for image descriptions

### DIFF
--- a/Sistemadeventas_AlmacenMera/Controllers/AsistenteController.cs
+++ b/Sistemadeventas_AlmacenMera/Controllers/AsistenteController.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Sistemadeventas_AlmacenMera.Models;
+using Sistemadeventas_AlmacenMera.Models.ViewModel;
+
+namespace Sistemadeventas_AlmacenMera.Controllers
+{
+    public class AsistenteController : Controller
+    {
+        private static readonly IReadOnlyCollection<AsistenteImagen> ImagenesPredefinidas = new List<AsistenteImagen>
+        {
+            new AsistenteImagen
+            {
+                Id = "frutas-frescas",
+                Nombre = "Canasta de frutas frescas",
+                DescripcionBreve = "Una selección colorida de frutas de temporada ideales para exhibiciones llamativas.",
+                DescripcionDetallada = "Observamos una canasta de frutas que incluye manzanas rojas, plátanos, naranjas y uvas. Es perfecta para promocionar productos frescos en la sección de abarrotes y resaltar la variedad disponible.",
+                RutaImagen = "img/asistente/frutas-frescas.svg",
+                Etiquetas = new[] { "frutas", "abarrotes", "frescura", "vitaminas" }
+            },
+            new AsistenteImagen
+            {
+                Id = "lacteos",
+                Nombre = "Refrigerador con lácteos",
+                DescripcionBreve = "Anaquel refrigerado con leche, yogures y queso listos para tus clientes.",
+                DescripcionDetallada = "Se aprecia un estante refrigerado con diferentes tipos de lácteos: botellas de leche, envases de yogur y bloques de queso. Es ideal para planificar promociones cruzadas con panadería o frutas.",
+                RutaImagen = "img/asistente/lacteos.svg",
+                Etiquetas = new[] { "lácteos", "refrigerado", "inventario", "promociones" }
+            },
+            new AsistenteImagen
+            {
+                Id = "limpieza",
+                Nombre = "Kit de limpieza del hogar",
+                DescripcionBreve = "Productos de limpieza esenciales para destacar combos de higiene.",
+                DescripcionDetallada = "En la imagen encontramos detergente líquido, limpiadores multiusos y guantes de goma. Es excelente para sugerir paquetes promocionales para el hogar y campañas de temporada.",
+                RutaImagen = "img/asistente/limpieza.svg",
+                Etiquetas = new[] { "hogar", "limpieza", "promoción", "combo" }
+            },
+            new AsistenteImagen
+            {
+                Id = "granos",
+                Nombre = "Sacos de granos básicos",
+                DescripcionBreve = "Sacos de arroz, maíz y legumbres listos para el almacén.",
+                DescripcionDetallada = "La escena muestra sacos apilados con granos secos como arroz y frijoles. Es útil para controlar existencias al mayoreo y planificar abastecimientos masivos.",
+                RutaImagen = "img/asistente/granos.svg",
+                Etiquetas = new[] { "granos", "inventario", "mayoreo", "almacén" }
+            }
+        };
+
+        public IActionResult Index()
+        {
+            if (!UsuarioAutenticado())
+            {
+                return RedirectToAction("Login", "Login");
+            }
+
+            var viewModel = new AsistenteViewModel
+            {
+                MensajeInicial = "Hola, soy MerAI. Selecciona una imagen para darte una descripción útil para tu negocio.",
+                Recomendaciones = new List<string>
+                {
+                    "Haz clic sobre una imagen para recibir una descripción detallada.",
+                    "Puedes usar las etiquetas como inspiración para nuevas categorías o promociones.",
+                    "Presiona \"Reiniciar conversación\" para comenzar de nuevo."
+                },
+                ImagenesDestacadas = ImagenesPredefinidas
+            };
+
+            return View(viewModel);
+        }
+
+        private bool UsuarioAutenticado()
+        {
+            return HttpContext.Session.GetInt32("UsuarioId").HasValue;
+        }
+    }
+}

--- a/Sistemadeventas_AlmacenMera/Models/AsistenteImagen.cs
+++ b/Sistemadeventas_AlmacenMera/Models/AsistenteImagen.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Sistemadeventas_AlmacenMera.Models
+{
+    public class AsistenteImagen
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Nombre { get; set; } = string.Empty;
+        public string DescripcionDetallada { get; set; } = string.Empty;
+        public string DescripcionBreve { get; set; } = string.Empty;
+        public string RutaImagen { get; set; } = string.Empty;
+        public IReadOnlyCollection<string> Etiquetas { get; set; } = new List<string>();
+    }
+}

--- a/Sistemadeventas_AlmacenMera/Models/ViewModel/AsistenteViewModel.cs
+++ b/Sistemadeventas_AlmacenMera/Models/ViewModel/AsistenteViewModel.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Sistemadeventas_AlmacenMera.Models.ViewModel
+{
+    public class AsistenteViewModel
+    {
+        public string NombreAsistente { get; set; } = "MerAI";
+        public string MensajeInicial { get; set; } = string.Empty;
+        public IReadOnlyCollection<string> Recomendaciones { get; set; } = new List<string>();
+        public IReadOnlyCollection<AsistenteImagen> ImagenesDestacadas { get; set; } = new List<AsistenteImagen>();
+    }
+}

--- a/Sistemadeventas_AlmacenMera/Views/Asistente/Index.cshtml
+++ b/Sistemadeventas_AlmacenMera/Views/Asistente/Index.cshtml
@@ -1,0 +1,81 @@
+@model Sistemadeventas_AlmacenMera.Models.ViewModel.AsistenteViewModel
+@{
+    ViewData["Title"] = "Asistente virtual";
+}
+
+<div class="row g-4">
+    <div class="col-lg-4">
+        <div class="card shadow-sm border-0 assistant-panel h-100">
+            <div class="card-header bg-primary text-white">
+                <div class="d-flex align-items-center gap-2">
+                    <span class="assistant-avatar">🤖</span>
+                    <div>
+                        <h5 class="mb-0">@Model.NombreAsistente</h5>
+                        <small class="text-white-50">Tu guía inteligente</small>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body d-flex flex-column">
+                <div id="assistantConversation" class="assistant-conversation flex-grow-1 mb-3">
+                    <div class="assistant-message assistant-message-bot">
+                        <div class="assistant-message-icon">🤖</div>
+                        <div>
+                            <div class="assistant-message-title">@Model.NombreAsistente</div>
+                            <p class="assistant-message-text">@Model.MensajeInicial</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="assistant-tips">
+                    <h6 class="text-muted text-uppercase fw-semibold small">Consejos rápidos</h6>
+                    <ul class="list-unstyled small text-muted">
+                        @foreach (var recomendacion in Model.Recomendaciones)
+                        {
+                            <li class="mb-1">💡 @recomendacion</li>
+                        }
+                    </ul>
+                </div>
+                <button type="button" id="resetAssistant" class="btn btn-outline-primary w-100 mt-3">
+                    Reiniciar conversación
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-8">
+        <div class="card shadow-sm border-0 h-100">
+            <div class="card-body">
+                <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center mb-3">
+                    <div>
+                        <h4 class="card-title mb-1">Galería inteligente</h4>
+                        <p class="card-subtitle text-muted">Selecciona una imagen y recibe una descripción lista para usar.</p>
+                    </div>
+                    <span class="badge bg-primary bg-gradient">Colección de ejemplo</span>
+                </div>
+                <div class="row row-cols-1 row-cols-md-2 g-3" id="assistantGallery">
+                    @foreach (var imagen in Model.ImagenesDestacadas)
+                    {
+                        <div class="col">
+                            <article class="assistant-image-card card h-100" data-id="@imagen.Id" data-title="@imagen.Nombre" data-description="@imagen.DescripcionDetallada" data-summary="@imagen.DescripcionBreve" data-tags="@string.Join(", ", imagen.Etiquetas)">
+                                <img src="@Url.Content($"~/{imagen.RutaImagen}")" class="card-img-top" alt="@imagen.Nombre" />
+                                <div class="card-body d-flex flex-column">
+                                    <h5 class="card-title">@imagen.Nombre</h5>
+                                    <p class="card-text text-muted flex-grow-1">@imagen.DescripcionBreve</p>
+                                    <div class="assistant-tags mt-2">
+                                        @foreach (var etiqueta in imagen.Etiquetas)
+                                        {
+                                            <span class="badge rounded-pill assistant-tag">@etiqueta</span>
+                                        }
+                                    </div>
+                                </div>
+                            </article>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="~/js/asistente.js" asp-append-version="true"></script>
+}

--- a/Sistemadeventas_AlmacenMera/Views/Shared/_Layout.cshtml
+++ b/Sistemadeventas_AlmacenMera/Views/Shared/_Layout.cshtml
@@ -42,6 +42,9 @@
                             <li class="nav-item">
                                 <a class="nav-link" asp-area="" asp-controller="Ventas" asp-action="PuntoVenta">Punto de Venta</a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link" asp-area="" asp-controller="Asistente" asp-action="Index">Asistente virtual</a>
+                            </li>
                         }
 
                         @if (esAdmin)

--- a/Sistemadeventas_AlmacenMera/wwwroot/css/site.css
+++ b/Sistemadeventas_AlmacenMera/wwwroot/css/site.css
@@ -70,3 +70,112 @@ body {
   background-color: #000;
   position: relative;
 }
+.assistant-panel {
+  border-radius: 1rem;
+}
+
+.assistant-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #0d6efd, #4dabf7);
+  font-size: 1.4rem;
+}
+
+.assistant-conversation {
+  background-color: #f8f9fa;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(13, 110, 253, 0.1);
+  padding: 1rem;
+  overflow-y: auto;
+  max-height: 420px;
+}
+
+.assistant-message {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  margin-bottom: 0.75rem;
+  background-color: #fff;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.assistant-message-user {
+  background: linear-gradient(135deg, #0d6efd, #60a5fa);
+  color: #fff;
+}
+
+.assistant-message-user .assistant-message-title,
+.assistant-message-user .assistant-message-text {
+  color: #fff;
+}
+
+.assistant-message-icon {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.assistant-message-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-bottom: 0.2rem;
+  color: #0b5ed7;
+}
+
+.assistant-message-text {
+  margin-bottom: 0;
+  font-size: 0.9rem;
+  color: #495057;
+}
+
+.assistant-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.assistant-tag {
+  background: rgba(13, 110, 253, 0.1);
+  color: #0b5ed7;
+  font-weight: 500;
+}
+
+.assistant-image-card {
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  border: 1px solid rgba(13, 110, 253, 0.1);
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.assistant-image-card img {
+  object-fit: cover;
+  height: 180px;
+  background-color: #f8f9fa;
+}
+
+.assistant-image-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.1);
+  border-color: rgba(13, 110, 253, 0.4);
+}
+
+.assistant-image-card.selected {
+  border-color: #0d6efd;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+.badge.bg-gradient {
+  background-image: linear-gradient(135deg, rgba(13, 110, 253, 0.85), rgba(99, 102, 241, 0.85));
+}
+
+@media (max-width: 991.98px) {
+  .assistant-conversation {
+    max-height: 320px;
+  }
+}

--- a/Sistemadeventas_AlmacenMera/wwwroot/img/asistente/frutas-frescas.svg
+++ b/Sistemadeventas_AlmacenMera/wwwroot/img/asistente/frutas-frescas.svg
@@ -1,0 +1,24 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="480" height="320" rx="32" fill="#FFF7ED"/>
+  <g filter="url(#shadow)">
+    <ellipse cx="240" cy="240" rx="160" ry="40" fill="#F2D6A2"/>
+  </g>
+  <g transform="translate(80 60)">
+    <path d="M140 140c-22 12-52 6-70-14-18-20-18-49 0-69 18-20 48-26 70-14 22 12 44 58 44 58s-22 27-44 39z" fill="#FF6B6B"/>
+    <path d="M118 52c8-18 18-32 30-40 12-8 24-12 36-12 12 0 22 4 30 12 16 16 16 40 0 56-16 16-72 28-72 28s-20-26-24-44z" fill="#FFA94D"/>
+    <path d="M210 110c14-16 40-24 60-16 20 8 32 28 30 48-2 20-18 40-40 46-22 6-76-18-76-18s12-44 26-60z" fill="#4CD1A1"/>
+    <path d="M192 32c0-18 16-32 36-32 20 0 36 14 36 32 0 18-16 38-36 38s-36-20-36-38z" fill="#8BC34A"/>
+    <path d="M80 28c0-12 12-22 28-22 16 0 28 10 28 22s-12 28-28 28c-16 0-28-16-28-28z" fill="#FFD43B"/>
+    <circle cx="150" cy="146" r="12" fill="#E03131"/>
+    <circle cx="182" cy="126" r="10" fill="#099268"/>
+    <circle cx="204" cy="162" r="14" fill="#22B8CF"/>
+  </g>
+  <defs>
+    <filter id="shadow" x="60" y="180" width="360" height="120" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="18" result="blur"/>
+      <feFlood flood-color="#F2D6A2" flood-opacity="0.4"/>
+      <feComposite in2="blur" operator="in"/>
+      <feComposite in="SourceGraphic"/>
+    </filter>
+  </defs>
+</svg>

--- a/Sistemadeventas_AlmacenMera/wwwroot/img/asistente/granos.svg
+++ b/Sistemadeventas_AlmacenMera/wwwroot/img/asistente/granos.svg
@@ -1,0 +1,25 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="480" height="320" rx="32" fill="#FFF4E6"/>
+  <g filter="url(#shadow)">
+    <ellipse cx="240" cy="244" rx="172" ry="48" fill="#F1D3A8"/>
+  </g>
+  <g transform="translate(80 68)">
+    <path d="M56 112c0-40 28-72 64-72s64 32 64 72-28 88-64 88-64-48-64-88z" fill="#FFA94D"/>
+    <path d="M64 112c0-32 22-56 48-56s48 24 48 56-22 68-48 68-48-36-48-68z" fill="#FFC078"/>
+    <path d="M156 96c0-36 26-64 58-64s58 28 58 64-26 80-58 80-58-44-58-80z" fill="#F59F00"/>
+    <path d="M166 96c0-28 20-48 48-48s48 20 48 48-20 60-48 60-48-32-48-60z" fill="#FFD43B"/>
+    <path d="M252 92c0-34 24-60 54-60s54 26 54 60-24 72-54 72-54-38-54-72z" fill="#E67700"/>
+    <path d="M264 92c0-26 18-44 42-44s42 18 42 44-18 52-42 52-42-26-42-52z" fill="#FFA94D"/>
+    <path d="M60 114c0-30 20-54 44-54s44 24 44 54-20 58-44 58-44-28-44-58z" fill="#FFF3BF" opacity="0.35"/>
+    <path d="M156 98c0-26 18-46 40-46s40 20 40 46-18 48-40 48-40-22-40-48z" fill="#FFE066" opacity="0.45"/>
+    <path d="M250 96c0-24 16-44 36-44s36 20 36 44-16 44-36 44-36-20-36-44z" fill="#FFD8A8" opacity="0.5"/>
+  </g>
+  <defs>
+    <filter id="shadow" x="52" y="180" width="376" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="18" result="blur"/>
+      <feFlood flood-color="#F1D3A8" flood-opacity="0.4"/>
+      <feComposite in2="blur" operator="in"/>
+      <feComposite in="SourceGraphic"/>
+    </filter>
+  </defs>
+</svg>

--- a/Sistemadeventas_AlmacenMera/wwwroot/img/asistente/lacteos.svg
+++ b/Sistemadeventas_AlmacenMera/wwwroot/img/asistente/lacteos.svg
@@ -1,0 +1,26 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="480" height="320" rx="32" fill="#E7F5FF"/>
+  <g filter="url(#shadow)">
+    <ellipse cx="240" cy="242" rx="168" ry="44" fill="#C5E4FF"/>
+  </g>
+  <g transform="translate(84 64)">
+    <rect x="40" y="72" width="80" height="120" rx="16" fill="#4DABF7"/>
+    <rect x="52" y="52" width="56" height="32" rx="10" fill="#228BE6"/>
+    <rect x="64" y="92" width="32" height="72" rx="8" fill="#D0EBFF"/>
+    <rect x="150" y="36" width="96" height="156" rx="24" fill="#A5D8FF"/>
+    <rect x="170" y="56" width="56" height="96" rx="16" fill="#F8F9FA"/>
+    <path d="M200 16c0-8 8-16 18-16s18 8 18 16v24h-36V16z" fill="#74C0FC"/>
+    <rect x="272" y="48" width="88" height="144" rx="20" fill="#FFE066"/>
+    <rect x="288" y="68" width="56" height="90" rx="14" fill="#FFF3BF"/>
+    <path d="M300 32c0-10 12-18 26-18s26 8 26 18v26h-52V32z" fill="#FCC419"/>
+    <rect x="112" y="158" width="236" height="12" rx="6" fill="#748FFC" opacity="0.35"/>
+  </g>
+  <defs>
+    <filter id="shadow" x="56" y="178" width="368" height="128" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="18" result="blur"/>
+      <feFlood flood-color="#C5E4FF" flood-opacity="0.4"/>
+      <feComposite in2="blur" operator="in"/>
+      <feComposite in="SourceGraphic"/>
+    </filter>
+  </defs>
+</svg>

--- a/Sistemadeventas_AlmacenMera/wwwroot/img/asistente/limpieza.svg
+++ b/Sistemadeventas_AlmacenMera/wwwroot/img/asistente/limpieza.svg
@@ -1,0 +1,26 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="480" height="320" rx="32" fill="#F3F0FF"/>
+  <g filter="url(#shadow)">
+    <ellipse cx="240" cy="236" rx="164" ry="46" fill="#DAD6FF"/>
+  </g>
+  <g transform="translate(96 68)">
+    <rect x="32" y="96" width="88" height="108" rx="20" fill="#845EF7"/>
+    <path d="M68 16h16c8 0 14 6 14 14v54H54V30c0-8 6-14 14-14z" fill="#9775FA"/>
+    <rect x="146" y="44" width="80" height="160" rx="22" fill="#51CF66"/>
+    <rect x="162" y="64" width="48" height="96" rx="14" fill="#C0F6D1"/>
+    <rect x="242" y="72" width="92" height="132" rx="18" fill="#FFD8A8"/>
+    <rect x="258" y="92" width="60" height="76" rx="12" fill="#FFE8CC"/>
+    <path d="M280 36c0-10 10-18 22-18s22 8 22 18v30h-44V36z" fill="#FFA94D"/>
+    <path d="M150 24h72l-12 24h-48L150 24z" fill="#63E6BE"/>
+    <rect x="52" y="146" width="72" height="16" rx="8" fill="#D0BFFF" opacity="0.6"/>
+    <rect x="164" y="178" width="96" height="12" rx="6" fill="#69DB7C" opacity="0.5"/>
+  </g>
+  <defs>
+    <filter id="shadow" x="60" y="172" width="360" height="132" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="18" result="blur"/>
+      <feFlood flood-color="#DAD6FF" flood-opacity="0.4"/>
+      <feComposite in2="blur" operator="in"/>
+      <feComposite in="SourceGraphic"/>
+    </filter>
+  </defs>
+</svg>

--- a/Sistemadeventas_AlmacenMera/wwwroot/js/asistente.js
+++ b/Sistemadeventas_AlmacenMera/wwwroot/js/asistente.js
@@ -1,0 +1,94 @@
+(function () {
+    const gallery = document.getElementById('assistantGallery');
+    const conversation = document.getElementById('assistantConversation');
+    const resetButton = document.getElementById('resetAssistant');
+
+    if (!gallery || !conversation) {
+        return;
+    }
+
+    const createMessage = (type, content, title) => {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('assistant-message');
+        wrapper.classList.add(type === 'bot' ? 'assistant-message-bot' : 'assistant-message-user');
+
+        const icon = document.createElement('div');
+        icon.classList.add('assistant-message-icon');
+        icon.textContent = type === 'bot' ? '🤖' : '🧑';
+
+        const body = document.createElement('div');
+        if (title) {
+            const heading = document.createElement('div');
+            heading.classList.add('assistant-message-title');
+            heading.textContent = title;
+            body.appendChild(heading);
+        }
+
+        const paragraph = document.createElement('p');
+        paragraph.classList.add('assistant-message-text');
+        paragraph.textContent = content;
+        body.appendChild(paragraph);
+
+        wrapper.appendChild(icon);
+        wrapper.appendChild(body);
+        return wrapper;
+    };
+
+    const scrollConversationToBottom = () => {
+        conversation.scrollTop = conversation.scrollHeight;
+    };
+
+    const clearSelection = () => {
+        const cards = gallery.querySelectorAll('.assistant-image-card');
+        cards.forEach(card => card.classList.remove('selected'));
+    };
+
+    gallery.addEventListener('click', (event) => {
+        const card = event.target.closest('.assistant-image-card');
+        if (!card) {
+            return;
+        }
+
+        clearSelection();
+        card.classList.add('selected');
+
+        const title = card.dataset.title ?? '';
+        const description = card.dataset.description ?? '';
+        const summary = card.dataset.summary ?? '';
+        const tags = card.dataset.tags ?? '';
+
+        const userMessage = createMessage('user', `Quisiera más información sobre "${title}".`);
+        conversation.appendChild(userMessage);
+
+        const botSegments = [description];
+        if (tags) {
+            botSegments.push(`Etiquetas sugeridas: ${tags}.`);
+        }
+        if (summary && summary !== description) {
+            botSegments.push(`Resumen rápido: ${summary}`);
+        }
+
+        botSegments.forEach((text, index) => {
+            const delay = 200 * (index + 1);
+            setTimeout(() => {
+                const botMessage = createMessage('bot', text, 'MerAI');
+                conversation.appendChild(botMessage);
+                scrollConversationToBottom();
+            }, delay);
+        });
+
+        scrollConversationToBottom();
+    });
+
+    if (resetButton) {
+        resetButton.addEventListener('click', () => {
+            const defaultMessage = conversation.querySelector('.assistant-message-bot');
+            conversation.innerHTML = '';
+            if (defaultMessage) {
+                conversation.appendChild(defaultMessage.cloneNode(true));
+            }
+            clearSelection();
+            scrollConversationToBottom();
+        });
+    }
+})();


### PR DESCRIPTION
## Summary
- add an Asistente controller, view model, and curated dataset to drive a virtual assistant experience
- build a dedicated view with interactive gallery UI, reusable styling, and scripted conversation flow
- surface the assistant from the main navigation and add illustrative SVG assets for the guided descriptions

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eabed7d1788332a94ec5580d25f3c8